### PR TITLE
Support installing LXD from snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
+.devcontainer
+.vscode
+Dockerfile

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,13 +25,16 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
+/.editorconfig
 /.fixtures.yml
 /Gemfile
 /.gitattributes
 /.gitignore
 /.gitlab-ci.yml
 /.pdkignore
+/.puppet-lint.rc
 /Rakefile
 /rakelib/
 /.rspec
@@ -40,3 +43,5 @@
 /.yardopts
 /spec/
 /.vscode/
+/.sync.yml
+/.devcontainer/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 ---
 require:
+- rubocop-performance
 - rubocop-rspec
-- rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.4'
   Include:
-  - "./**/*.rb"
+  - "**/*.rb"
   Exclude:
   - bin/*
   - ".vendor/**/*"
@@ -18,16 +18,9 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
-  Enabled: false
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/**/*
-  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -36,14 +29,13 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,7 +64,7 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -87,25 +79,169 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+Bundler/InsecureProtocolSource:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+Gemspec/DuplicatedAssignment:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+Gemspec/OrderedDependencies:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Lint/BigDecimalNew:
+  Enabled: false
+Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/ErbNewArguments:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/HashCompareByIdentity:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: false
+Lint/MissingCopEnableDirective:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+Lint/OrderedMagicComments:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
+Lint/RedundantWithIndex:
+  Enabled: false
+Lint/RedundantWithObject:
+  Enabled: false
+Lint/RegexpAsCondition:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Lint/SafeNavigationConsistency:
+  Enabled: false
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/ShadowedArgument:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/ToJSON:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UriEscapeUnescape:
+  Enabled: false
+Lint/UriRegexp:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -119,19 +255,265 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Migration/DepartmentName:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/BlockParameterName:
+  Enabled: false
+Naming/HeredocDelimiterCase:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Performance/UnfreezeString:
+  Enabled: false
+Performance/UriDefaultParser:
+  Enabled: false
+RSpec/Be:
+  Enabled: false
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+RSpec/Capybara/VisibilityMatcher:
+  Enabled: false
+RSpec/ContextMethod:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/EmptyHook:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/MessageExpectation:
+RSpec/ExampleWithoutDescription:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+RSpec/FactoryBot/FactoryClassName:
+  Enabled: false
+RSpec/HooksBeforeExamples:
+  Enabled: false
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+RSpec/ImplicitSubject:
+  Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+RSpec/LetBeforeExamples:
+  Enabled: false
+RSpec/MissingExampleGroupArgument:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/MultipleSubjects:
+  Enabled: false
 RSpec/NestedGroups:
+  Enabled: false
+RSpec/PredicateMatcher:
+  Enabled: false
+RSpec/ReceiveCounts:
+  Enabled: false
+RSpec/ReceiveNever:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+RSpec/ReturnFromStub:
+  Enabled: false
+RSpec/SharedExamples:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/UnspecifiedException:
+  Enabled: false
+RSpec/VariableDefinition:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/Yield:
+  Enabled: false
+Security/Open:
+  Enabled: false
+Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/ColonMethodDefinition:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false
+Style/Dir:
+  Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
+Style/EmptyBlockParameter:
+  Enabled: false
+Style/EmptyLambdaParameter:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EvalWithLocation:
+  Enabled: false
+Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/MinMax:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NegatedUnless:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/OrAssignment:
+  Enabled: false
+Style/RandomWithOffset:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
+Style/RedundantConditional:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/RedundantSort:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/Strip:
+  Enabled: false
 Style/SymbolProc:
+  Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingMethodEndStatement:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/CollectionCompact:
+  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
+Style/NilLambda:
+  Enabled: false
+Style/RedundantArgument:
+  Enabled: false
+Style/SwapValues:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,17 +17,17 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
@@ -43,16 +43,6 @@ gems['puppet'] = location_for(puppet_version)
 
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
-
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
-end
 
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,88 @@
-require 'rubygems'
+# frozen_string_literal: true
+
+require 'bundler'
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
+require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
+
+def changelog_user
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  return unless Rake.application.top_level_tasks.include? "changelog"
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
+
+PuppetLint.configuration.send('disable_relative')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["enhancement", "feature"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bug", "documentation", "bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on recent features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+EOM
+  end
+end
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,11 @@
-## Basic configuration of LXD
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Basic configuration of LXD
+#
+# @api private
+#
 class lxd::config{
 
     # params from main module

--- a/manifests/container.pp
+++ b/manifests/container.pp
@@ -1,8 +1,22 @@
-## LXD container define
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Manage LXD container
+#
+# @param ensure
+#   Ensure the state of the resource
+# @param image
+#   Image from which to create the container
+# @param config
+#   Config values for the container
+# @param devices
+#   Devices to be attached to container
+# @param profiles
+#   Profiles to be assigned to container
+# @param state
+#   State of the container
+#
 define lxd::container(
     $image,
     $config = {},

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -1,8 +1,18 @@
-## Manage lxd images
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Manage LXD images
+#
+# @param ensure
+#   Ensure the state of the resource
+# @param repo_url
+#   LXD image mirror URL
+# @param image_file
+#   Name of the image file
+# @param image_alias
+#   Alias for the image being downloaded
+#
 define lxd::image(
     $repo_url,
     $image_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,11 +35,16 @@ class lxd(
     Enum['present', 'absent'] $lxd_core_trust_password_ensure  = $lxd::params::lxd_core_trust_password_ensure,
     Enum['deb', 'snap']       $provider                        = $lxd::params::lxd_provider
 ) inherits lxd::params {
-    contain ::lxd::install
-    contain ::lxd::config
+    contain lxd::install
+    contain lxd::config
 
-    Class['lxd::install']
-    -> Class['lxd::config']
+    if $ensure == 'present' {
+      Class['lxd::install']
+      -> Class['lxd::config']
+    } else {
+      Class['lxd::config']
+      -> Class['lxd::install']
+    }
 
     # Every container has to be created after LXD is installed, of course
     # Container can have multiple profiles so better make sure that

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,10 @@
 #   Manage LXD default trust password for clustering
 # @param lxd_core_trust_password
 #   LXD trust password for clusters
+# @param manage_snapd
+#   If class should manage install of `snapd`.
+#   There might be cases where the package is managed externally
+#   and would cause conflict.
 #
 class lxd(
     Optional[String]          $version                         = $lxd::params::version,
@@ -33,7 +37,8 @@ class lxd(
     Enum['present', 'absent'] $lxd_core_https_address_ensure   = $lxd::params::lxd_core_https_address_ensure,
     Optional[String]          $lxd_core_trust_password         = $lxd::params::lxd_core_trust_password,
     Enum['present', 'absent'] $lxd_core_trust_password_ensure  = $lxd::params::lxd_core_trust_password_ensure,
-    Enum['package', 'snap']   $provider                        = $lxd::params::lxd_provider
+    Enum['package', 'snap']   $provider                        = $lxd::params::lxd_provider,
+    Boolean                   $manage_snapd                    = $lxd::params::manage_snapd
 ) inherits lxd::params {
     contain lxd::install
     contain lxd::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class lxd(
     $lxd_core_https_address_ensure = $lxd::params::lxd_core_https_address_ensure,
     $lxd_core_trust_password = $lxd::params::lxd_core_trust_password,
     $lxd_core_trust_password_ensure = $lxd::params::lxd_core_trust_password_ensure,
+    Enum['deb', 'snap'] $provider = $lxd::params::lxd_provider
 ) inherits lxd::params {
     contain ::lxd::install
     contain ::lxd::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,39 @@
-## Init class
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Manage LXD and its configuration
+#
+# @param ensure
+#   Ensure the state of the resources
+# @param version
+#   Version to be installed
+# @param install_options
+#   Additional install options passed to apt eg. `-t trusty-backports`
+# @param lxd_auto_update_interval_ensure
+#   Manage Auto Update Interval
+# @param lxd_auto_update_interval
+#   Default interval to update remote images, 0 to disable
+# @param lxd_core_https_address_ensure
+#   Manage LXD Core HTTPS Address
+# @param lxd_core_https_address
+#   HTTPS address on which LXD to listen to
+# @param lxd_core_trust_password_ensure
+#   Manage LXD default trust password for clustering
+# @param lxd_core_trust_password
+#   LXD trust password for clusters
+#
 class lxd(
-    $version = $lxd::params::version,
-    $ensure  = $lxd::params::ensure,
-    $install_options = $lxd::params::install_options,
-    $lxd_auto_update_interval = $lxd::params::lxd_auto_update_interval,
-    $lxd_auto_update_interval_ensure = $lxd::params::lxd_auto_update_interval_ensure,
-    $lxd_core_https_address = $lxd::params::lxd_core_https_address,
-    $lxd_core_https_address_ensure = $lxd::params::lxd_core_https_address_ensure,
-    $lxd_core_trust_password = $lxd::params::lxd_core_trust_password,
-    $lxd_core_trust_password_ensure = $lxd::params::lxd_core_trust_password_ensure,
-    Enum['deb', 'snap'] $provider = $lxd::params::lxd_provider
+    Optional[String]          $version                         = $lxd::params::version,
+    Enum['present', 'absent'] $ensure                          = $lxd::params::ensure,
+    Array[String]             $install_options                 = $lxd::params::install_options,
+    Integer                   $lxd_auto_update_interval        = $lxd::params::lxd_auto_update_interval,
+    Enum['present', 'absent'] $lxd_auto_update_interval_ensure = $lxd::params::lxd_auto_update_interval_ensure,
+    Optional[String]          $lxd_core_https_address          = $lxd::params::lxd_core_https_address,
+    Enum['present', 'absent'] $lxd_core_https_address_ensure   = $lxd::params::lxd_core_https_address_ensure,
+    Optional[String]          $lxd_core_trust_password         = $lxd::params::lxd_core_trust_password,
+    Enum['present', 'absent'] $lxd_core_trust_password_ensure  = $lxd::params::lxd_core_trust_password_ensure,
+    Enum['deb', 'snap']       $provider                        = $lxd::params::lxd_provider
 ) inherits lxd::params {
     contain ::lxd::install
     contain ::lxd::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class lxd(
     Enum['present', 'absent'] $lxd_core_https_address_ensure   = $lxd::params::lxd_core_https_address_ensure,
     Optional[String]          $lxd_core_trust_password         = $lxd::params::lxd_core_trust_password,
     Enum['present', 'absent'] $lxd_core_trust_password_ensure  = $lxd::params::lxd_core_trust_password_ensure,
-    Enum['deb', 'snap']       $provider                        = $lxd::params::lxd_provider
+    Enum['package', 'snap']   $provider                        = $lxd::params::lxd_provider
 ) inherits lxd::params {
     contain lxd::install
     contain lxd::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,8 +4,28 @@
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
 
 class lxd::install {
-    package { 'lxd':
+    if $::lxd::provider == 'deb' {
+      package { 'lxd':
         ensure          => $::lxd::ensure,
         install_options => $::lxd::install_options,
+      }
+    } else {
+      package { 'snapd':
+        ensure => $::lxd::ensure,
+      }
+
+      exec { 'install snap core':
+        path    => '/usr/bin:/bin',
+        command => '/usr/bin/snap install core',
+        unless  => '/usr/bin/snap list core',
+        require => Package['snapd']
+      }
+
+      exec { 'install lxd':
+        path    => '/usr/bin:/bin',
+        command => '/usr/bin/snap install lxd',
+        unless  => '/usr/bin/snap list lxd',
+        require => Exec['install snap core']
+      }
     }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,11 +26,19 @@ class lxd::install {
         unless  => '/usr/bin/snap list core',
       }
 
-      exec { 'install lxd':
-        path    => '/usr/bin:/bin',
-        command => '/usr/bin/snap install lxd',
-        unless  => '/usr/bin/snap list lxd',
-        require => Exec['install snap core']
+      if $lxd::ensure == 'present' {
+        exec { 'install lxd':
+          path    => '/usr/bin:/bin',
+          command => '/usr/bin/snap install lxd',
+          unless  => '/usr/bin/snap list lxd',
+          require => Exec['install snap core']
+        }
+      } else {
+        exec { 'remove lxd':
+          path    => '/usr/bin:/bin',
+          command => '/usr/bin/snap remove lxd',
+          unless  => '! /usr/bin/snap list lxd >/dev/null 2>&1',
+        }
       }
     }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,15 +13,17 @@ class lxd::install {
         install_options => $::lxd::install_options,
       }
     } else {
-      package { 'snapd':
-        ensure => $::lxd::ensure,
+      if $lxd::manage_snapd {
+        package { 'snapd':
+          ensure => $::lxd::ensure,
+          before => Exec['install snap core']
+        }
       }
 
       exec { 'install snap core':
         path    => '/usr/bin:/bin',
         command => '/usr/bin/snap install core',
         unless  => '/usr/bin/snap list core',
-        require => Package['snapd']
       }
 
       exec { 'install lxd':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@
 # @api private
 #
 class lxd::install {
-    if $::lxd::provider == 'deb' {
+    if $::lxd::provider == 'package' {
       package { 'lxd':
         ensure          => $::lxd::ensure,
         install_options => $::lxd::install_options,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,11 @@
-## Installing LXD
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Performs install actions for LXD
+#
+# @api private
+#
 class lxd::install {
     if $::lxd::provider == 'deb' {
       package { 'lxd':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,5 @@ class lxd::params {
     $lxd_core_trust_password = undef
     $lxd_core_trust_password_ensure = 'absent'
     $lxd_provider = 'package'
+    $manage_snapd = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,5 +20,5 @@ class lxd::params {
     # setting the server's trust password
     $lxd_core_trust_password = undef
     $lxd_core_trust_password_ensure = 'absent'
-    $lxd_provider = 'deb'
+    $lxd_provider = 'package'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,11 @@
-## LXD default params
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary LXD default parameters
+#
+# @api private
+#
 class lxd::params {
     $ensure = present
     $version = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,4 +17,5 @@ class lxd::params {
     # setting the server's trust password
     $lxd_core_trust_password = undef
     $lxd_core_trust_password_ensure = 'absent'
+    $lxd_provider = 'deb'
 }

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -1,8 +1,18 @@
-## Creating LXD profiles
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Manage LXD profiles
+#
+# @param ensure
+#   Ensure the state of the resource
+# @param devices
+#   Devices to be included in the profile
+# @param config
+#   Config values to be included in the profile
+# @param description
+#   Description for the profile
+#
 define lxd::profile(
     $devices,
     $config,

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -1,8 +1,18 @@
-## Configuration of storage pools for LXD
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
-
+#
+# @summary Manage LXD storage pool
+#
+# @param ensure
+#   Ensure the state of the resource
+# @param driver
+#   Backend storage driver
+# @param config
+#   Config values for the storage
+# @param description
+#   Description of the storage backend
+#
 define lxd::storage(
     $driver,
     $config,

--- a/metadata.json
+++ b/metadata.json
@@ -16,9 +16,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04",
-        "18.04",
-        "16.04",
-        "14.04"
+        "18.04"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -1,17 +1,21 @@
 {
-  "name": "lxd-puppet-module",
+  "name": "lxd-lxd_puppet_module",
   "version": "1.0.0",
   "author": "Filip Dorosz",
-  "summary": "",
+  "summary": "Puppet module to manage LXD hosts",
   "license": "BSD-3-Clause",
-  "source": "",
+  "source": "https://github.com/ovh/lxd-puppet-module",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 6.0.0 < 6.6.0"
+    }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "20.04",
         "18.04",
         "16.04",
         "14.04"
@@ -21,10 +25,10 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 5.4.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.18.0",
-  "template-url": "pdk-default#1.18.0",
-  "template-ref": "tags/1.18.0-0-g095317c"
+  "pdk-version": "2.2.0",
+  "template-url": "pdk-default#2.2.0",
+  "template-ref": "tags/2.2.0-0-g2381db6"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -48,7 +48,7 @@ describe 'lxd' do
                     let(:params) do
                         super().merge(
                             {
-                                'provider' => 'deb',
+                                'provider' => 'package',
                             }
                         )
                     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,46 @@ describe '::lxd' do
     let(:params) {{
         'lxd_auto_update_interval' => 0,
     }}
-    # Test packages which should be installed
-    it { is_expected.to contain_package('lxd').with_ensure('present')}
+
+    it do
+        is_expected.to contain_class('lxd::install').that_comes_before('lxd::config')
+    end
+    it do
+        is_expected.to contain_class('lxd::config').that_comes_after('lxd::install')
+    end
+
+    context 'with install from deb package' do
+        let(:params) do
+            super().merge({
+                'provider' => 'deb',
+            })
+        end
+        # Test packages which should be installed
+        it { is_expected.to contain_package('lxd').with_ensure('present')}
+    end
+
+    context 'with install from snap' do
+        let(:params) do
+            super().merge({
+                'provider' => 'snap',
+            })
+        end
+        it do
+            is_expected.to contain_package('snapd').with_ensure('present')
+        end
+        it do
+            is_expected.to contain_exec('install snap core').with(
+                'path' => '/usr/bin:/bin',
+                'command' => '/usr/bin/snap install core',
+                'unless' => '/usr/bin/snap list core',
+            ).that_requires('Package[snapd]')
+        end
+        it do
+            is_expected.to contain_exec('install lxd').with(
+                'path' => '/usr/bin:/bin',
+                'command' => '/usr/bin/snap install lxd',
+                'unless' => '/usr/bin/snap list lxd',
+            ).that_requires('Exec[install snap core]')
+        end
+    end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -164,11 +164,11 @@ describe 'lxd' do
                         ).that_requires('Package[snapd]')
                     end
                     it do
-                        is_expected.to contain_exec('install lxd').with(
+                        is_expected.to contain_exec('remove lxd').with(
                             'path' => '/usr/bin:/bin',
-                            'command' => '/usr/bin/snap install lxd',
-                            'unless' => '/usr/bin/snap list lxd',
-                        ).that_requires('Exec[install snap core]')
+                            'command' => '/usr/bin/snap remove lxd',
+                            'unless' => '! /usr/bin/snap list lxd >/dev/null 2>&1',
+                        )
                     end
                 end
             end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,51 +4,90 @@
 
 require 'spec_helper'
 
-describe '::lxd' do
+describe 'lxd' do
+    on_supported_os.each do | os, facts |
+        context "on #{os}" do
+            let(:facts) do
+                facts
+            end
 
-    let(:params) {{
-        'lxd_auto_update_interval' => 0,
-    }}
+            describe 'with ensure => present' do
+                let(:params) do
+                    {
+                        'ensure' => 'present',
+                        'lxd_auto_update_interval' => 0,
+                    }
+                end
+                it do
+                    is_expected.to contain_class('lxd::install').that_comes_before(
+                        'Class[lxd::config]',
+                    )
+                end
+                it do
+                    is_expected.to contain_class('lxd::config')
+                end
+            end
 
-    it do
-        is_expected.to contain_class('lxd::install').that_comes_before('lxd::config')
-    end
-    it do
-        is_expected.to contain_class('lxd::config').that_comes_after('lxd::install')
-    end
+            describe 'with ensure => absent' do
+                let(:params) do
+                    {
+                        'ensure' => 'absent',
+                        'lxd_auto_update_interval' => 0,
+                    }
+                end
+                it do
+                    is_expected.to contain_class('lxd::install')
+                end
+                it do
+                    is_expected.to contain_class('lxd::config').that_comes_before(
+                        'Class[lxd::install]',
+                    )
+                end
 
-    context 'with install from deb package' do
-        let(:params) do
-            super().merge({
-                'provider' => 'deb',
-            })
-        end
-        # Test packages which should be installed
-        it { is_expected.to contain_package('lxd').with_ensure('present')}
-    end
-
-    context 'with install from snap' do
-        let(:params) do
-            super().merge({
-                'provider' => 'snap',
-            })
-        end
-        it do
-            is_expected.to contain_package('snapd').with_ensure('present')
-        end
-        it do
-            is_expected.to contain_exec('install snap core').with(
-                'path' => '/usr/bin:/bin',
-                'command' => '/usr/bin/snap install core',
-                'unless' => '/usr/bin/snap list core',
-            ).that_requires('Package[snapd]')
-        end
-        it do
-            is_expected.to contain_exec('install lxd').with(
-                'path' => '/usr/bin:/bin',
-                'command' => '/usr/bin/snap install lxd',
-                'unless' => '/usr/bin/snap list lxd',
-            ).that_requires('Exec[install snap core]')
+                describe 'with package install' do
+                    let(:params) do
+                        super().merge(
+                            {
+                                'provider' => 'deb',
+                            }
+                        )
+                    end
+                    it do
+                        is_expected.to contain_package('lxd').with(
+                            'ensure' => 'absent',
+                            'install_options' => [],
+                        )
+                    end
+                    it { is_expected.not_to contain_exec('install snap core') }
+                    it { is_expected.not_to contain_exec('install lxd') }
+                end
+                describe 'with snap install' do
+                    let(:params) do
+                        super().merge(
+                            {
+                                'provider' => 'snap',
+                            }
+                        )
+                    end
+                    it do
+                        is_expected.to contain_package('snapd').with_ensure('absent')
+                    end
+                    it do
+                        is_expected.to contain_exec('install snap core').with(
+                            'path' => '/usr/bin:/bin',
+                            'command' => '/usr/bin/snap install core',
+                            'unless' => '/usr/bin/snap list core',
+                        ).that_requires('Package[snapd]')
+                    end
+                    it do
+                        is_expected.to contain_exec('install lxd').with(
+                            'path' => '/usr/bin:/bin',
+                            'command' => '/usr/bin/snap install lxd',
+                            'unless' => '/usr/bin/snap list lxd',
+                        ).that_requires('Exec[install snap core]')
+                    end
+                end
+            end
         end
     end
 end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,8 @@
+# Use default_module_facts.yml for module specific facts.
+#
+# Facts specified here will override the values provided by rspec-puppet-facts.
+---
+ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+is_pe: false
+macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,73 @@
-require 'rubygems'
-require 'rspec-puppet'
-require 'puppetlabs_spec_helper/module_spec_helper'
-
-fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+# frozen_string_literal: true
 
 RSpec.configure do |c|
-  c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests')
-  c.parser       = 'future'
+  c.mock_with :rspec
 end
+
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+
+require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
+
+include RspecPuppetFacts
+
+default_facts = {
+  puppetversion: Puppet.version,
+  facterversion: Facter.version,
+}
+
+default_fact_files = [
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml')),
+]
+
+default_fact_files.each do |f|
+  next unless File.exist?(f) && File.readable?(f) && File.size?(f)
+
+  begin
+    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+  rescue => e
+    RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
+  end
+end
+
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
+RSpec.configure do |c|
+  c.default_facts = default_facts
+  c.before :each do
+    # set to strictest setting for testing
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = :warning
+    Puppet.settings[:strict_variables] = true
+  end
+  c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
+  c.after(:suite) do
+  end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+end
+
+# Ensures that a module is defined
+# @param module_name Name of the module
+def ensure_module_defined(module_name)
+  module_name.split('::').reduce(Object) do |last_module, next_module|
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
+    last_module.const_get(next_module, false)
+  end
+end
+
+# 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
While not the most popular option a lot of people use it to get LXD up and running fast. Changes made:

* Added variable to control how `lxd` is expected to be installed. Defaults to `deb`. If support for non-Debian family OS's is expected to be handled by the module, it might make sense to rename the `deb` option to something else. As per the project description, it doesn't seem to be any such plans.
* Added logic to determine how to install the package (package resource or snap exec). Atm it is expected that `snapd` will be managed by the module, but I can easily switch it to be a configurable option that defaults to true.
* Included tests for this logic