### PR TITLE
Support installing LXD from snap

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ class lxd(
     $lxd_core_https_address_ensure = $lxd::params::lxd_core_https_address_ensure,
     $lxd_core_trust_password = $lxd::params::lxd_core_trust_password,
     $lxd_core_trust_password_ensure = $lxd::params::lxd_core_trust_password_ensure,
+    Enum['deb', 'snap'] $lxd_package_provider = $lxd::params::package_provider,
+    Boolean             $manage_snapd = $lxd::params::manage_snapd
 ) inherits lxd::params {
     contain ::lxd::install
     contain ::lxd::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,8 +13,8 @@ class lxd(
     $lxd_core_https_address_ensure = $lxd::params::lxd_core_https_address_ensure,
     $lxd_core_trust_password = $lxd::params::lxd_core_trust_password,
     $lxd_core_trust_password_ensure = $lxd::params::lxd_core_trust_password_ensure,
-    Enum['deb', 'snap'] $lxd_package_provider = $lxd::params::package_provider,
-    Boolean             $manage_snapd = $lxd::params::manage_snapd
+    Enum['deb', 'snap'] $lxd_package_provider = $lxd::params::lxd_package_provider,
+    Boolean             $manage_snapd = $lxd::params::lxd_manage_snapd
 ) inherits lxd::params {
     contain ::lxd::install
     contain ::lxd::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,8 +4,32 @@
 # Copyright 2020 The LXD Puppet module Authors. All rights reserved.
 
 class lxd::install {
-    package { 'lxd':
+    if $::lxd::lxd_package_provider == 'deb' {
+      package { 'lxd':
         ensure          => $::lxd::ensure,
         install_options => $::lxd::install_options,
+      }
+    } else {
+      if $::lxd::manage_snapd {
+        package { 'snapd':
+          ensure => $::lxd::ensure,
+          before => Exec['install lxd']
+        }
+      }
+
+      if $::lxd::ensure == 'present' {
+        exec { 'install lxd':
+          path    => '/bin:/usr/bin',
+          command => '/usr/bin/snap install lxd',
+          unless  => '/usr/bin/snap list lxd',
+        }
+      } else {
+        exec { 'remove lxd':
+          path    => '/bin:/usr/bin',
+          command => '/usr/bin/snap remove lxd',
+          unless  => '! /usr/bin/snap list lxd >/dev/null 2>&1',
+          before  => Package['snapd']
+        }
+      }
     }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,4 +17,6 @@ class lxd::params {
     # setting the server's trust password
     $lxd_core_trust_password = undef
     $lxd_core_trust_password_ensure = 'absent'
+    $lxd_package_provider = 'deb'
+    $lxd_manage_snapd = true
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,50 @@ describe '::lxd' do
     let(:params) {{
         'lxd_auto_update_interval' => 0,
     }}
-    # Test packages which should be installed
-    it { is_expected.to contain_package('lxd').with_ensure('present')}
+
+    describe 'when installed from deb package' do
+      let(:params) do
+        super().merge(
+            {
+              'lxd_package_provider' => 'deb',
+            }
+        )
+      end
+      # Test packages which should be installed
+      it { is_expected.to contain_package('lxd').with_ensure('present')}
+    end
+
+    describe 'when installed via snap' do
+      let(:params) do
+        super().merge(
+          {
+            'lxd_package_provider' => 'snap',
+          }
+        )
+      end
+      context 'and $lxd::manage_snapd is true' do
+        let(:params) do
+          super().merge(
+            {
+              'manage_snapd' => true,
+            }
+          )
+        end
+        it { is_expected.not_to contain_package('lxd') }
+        it { is_expected.to contain_package('snapd').with_ensure('present')}
+        it { is_expected.to contain_exec('install lxd') }
+      end
+      context 'and $lxd::manage_snapd is false' do
+        let(:params) do
+          super().merge(
+            {
+              'manage_snapd' => false,
+            }
+          )
+        end
+        it { is_expected.not_to contain_package('lxd') }
+        it { is_expected.not_to contain_package('snapd') }
+        it { is_expected.to contain_exec('install lxd') }
+      end
+    end
 end


### PR DESCRIPTION
While not the most popular option a lot of people use it to get LXD up and running fast. Changes made:

 * Added variable to control how lxd is expected to be installed. Defaults to deb.
 * Added logic to determine how to install the package (package resource or snap exec).
   Atm it is expected that snapd will be managed by the module, but I can be turned off
   by setting `manage_snapd` to false.
 * Included tests for this logic